### PR TITLE
Disabling strict mode for tests

### DIFF
--- a/base_test.go
+++ b/base_test.go
@@ -41,7 +41,7 @@ func makeTestDSN(dbName string) string {
 	if !strings.Contains(host, ":") {
 		host += ":3306"
 	}
-	fmt.Fprintf(&buf, "tcp(%s)/%s?strict=true", host, dbName)
+	fmt.Fprintf(&buf, "tcp(%s)/%s", host, dbName)
 	return buf.String()
 }
 


### PR DESCRIPTION
Since go-sql-driver/mysql@a8b7ed4454a6a4f98f85d3ad558cd6d97cec6959 no longer supports strict mode, I am removing from the base test so squalor is compatible with the driver going forward.

see: https://github.com/go-sql-driver/mysql/wiki/strict-mode